### PR TITLE
Improved organisation of R2DT results

### DIFF
--- a/data/crw-fasta-no-pseudoknots/d.5.e.D.melanogaster.2.fasta
+++ b/data/crw-fasta-no-pseudoknots/d.5.e.D.melanogaster.2.fasta
@@ -1,3 +1,3 @@
 >generated from crw-bpseq/d.5.e.D.melanogaster.2.bpseq by bpseq2fasta
-GCCAACGACCAUACCACGCUGAAUACAUCGGUUCUCGUCCGAUCACCGAAAUUAAGCAGCGUCGGGCGCGGUUAGUACUUAGAUGAGGGACCGCUUGGGAACACCGCGUGUUGUUGGCCUCGUCCACAACUUUUU
-(((((((((....((((((((.......((((............))))........)))))).)).(((((......((.((.((......)))).)).....))))).))))))))).................
+GCCAACGACCAUACCACGCUGAAUACAUCGGUUCUCGUCCGAUCACCGAAAUUAAGCAGCGUCGGGCGCGGUUAGUACUUAGAUGAGGGACCGCUUGGGAACACCGCGUGUUGUUGGCCU
+(((((((((....((((((((.......((((............))))........)))))).)).(((((......((.((.((......)))).)).....))))).)))))))))..

--- a/r2dt.py
+++ b/r2dt.py
@@ -183,8 +183,27 @@ def draw(ctx, fasta_input, output_folder):
 
     # move svg files to the final location
     for folder in [crw_output, ribovision_ssu_output, ribovision_lsu_output, rfam_output, gtrnadb_output, rfam_trna_output]:
-        if len(glob.glob(os.path.join(folder, '*.colored.svg'))):
-            os.system('mv {0}/*.colored.svg {1}'.format(folder, output_folder))
+        organise_results(folder, output_folder)
+
+
+def organise_results(results_folder, output_folder):
+    destination = os.path.join(output_folder, 'results')
+    svg_folder = os.path.join(destination, 'svg')
+    thumbnail_folder = os.path.join(destination, 'thumbnail')
+    fasta_folder = os.path.join(destination, 'fasta')
+    for folder in [destination, svg_folder, thumbnail_folder, fasta_folder]:
+        os.system('mkdir -p {}'.format(folder))
+
+    svgs = glob.glob(os.path.join(results_folder, '*.colored.svg'))
+    if len(svgs):
+        for svg in svgs:
+            with open(svg, 'r') as f_svg:
+                thumbnail = generate_thumbnail(f_svg.read(), svg)
+                with open(svg.replace('.colored.', '.thumbnail.'), 'w') as f_thumbnail:
+                    f_thumbnail.write(thumbnail)
+        os.system('mv {0}/*.colored.svg {1}'.format(results_folder, svg_folder))
+        os.system('mv {0}/*.thumbnail.svg {1}'.format(results_folder, thumbnail_folder))
+        os.system('mv {0}/*.fasta {1}'.format(results_folder, fasta_folder))
 
 
 @cli.group('gtrnadb')

--- a/r2dt.py
+++ b/r2dt.py
@@ -178,8 +178,10 @@ def draw(ctx, fasta_input, output_folder):
     if subset:
         get_subset_fasta(fasta_input, subset_fasta, subset)
         print('Analysing {} sequences with Rfam tRNA'.format(len(subset)))
-        rfam.cmsearch_nohmm_mode(subset_fasta, output_folder, 'RF00005')
-        rfam.generate_2d('RF00005', output_folder, subset_fasta, False)
+        trna_ids = rfam.cmsearch_nohmm_mode(subset_fasta, output_folder, 'RF00005')
+        if trna_ids:
+            get_subset_fasta(fasta_input, subset_fasta, trna_ids)
+            rfam.generate_2d('RF00005', output_folder, subset_fasta, False)
 
     # move svg files to the final location
     result_folders = [crw_output, ribovision_ssu_output, ribovision_lsu_output, rfam_output, gtrnadb_output, rfam_trna_output]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 click==7.0
+colorhash

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -214,9 +214,9 @@ class TestSingleEntry(unittest.TestCase):
 
     def test_examples(self):
         for filename in self.files:
-            new_file = os.path.join(self.test_results, filename)
+            new_file = os.path.join(self.test_results, 'results', 'svg', filename)
             reference_file = os.path.join(self.precomputed_results, filename)
-            self.assertTrue(os.path.exists(new_file))
+            self.assertTrue(os.path.exists(new_file), 'File {} does not exist'.format(new_file))
             self.assertTrue(filecmp.cmp(new_file, reference_file), 'File {} does not match'.format(new_file))
 
     def tearDown(self):

--- a/utils/rfam.py
+++ b/utils/rfam.py
@@ -540,7 +540,8 @@ def cmsearch_nohmm_mode(fasta_input, output_folder, rfam_acc):
     Run cmsearch on the fasta sequences using cmsearch in the --nohmm mode
     to get potentially missing hits.
     """
-    tblout = os.path.join(output_folder, 'cmsearch.tblout')
+    subfolder = os.path.join(output_folder, 'RF00005'
+    tblout = os.path.join(subfolder, 'cmsearch.tblout')
     cmd = 'cmsearch --nohmm --tblout {tblout} {cm} {fasta_input}'.format(
         cm=os.path.join(config.RFAM_DATA, rfam_acc, '{}.cm'.format(rfam_acc)),
         tblout=tblout,
@@ -548,7 +549,7 @@ def cmsearch_nohmm_mode(fasta_input, output_folder, rfam_acc):
     )
     print(cmd)
     os.system(cmd)
-    f_out = os.path.join(output_folder, 'hits.txt')
+    f_out = os.path.join(subfolder, 'hits.txt')
     cmd = "cat %s | grep -v '^#' | awk -v OFS='\t' '{print $1, $4, \"PASS\"}' > %s" % (tblout, f_out)
     os.system(cmd)
     return f_out

--- a/utils/rfam.py
+++ b/utils/rfam.py
@@ -540,10 +540,12 @@ def cmsearch_nohmm_mode(fasta_input, output_folder, rfam_acc):
     Run cmsearch on the fasta sequences using cmsearch in the --nohmm mode
     to get potentially missing hits.
     """
-    subfolder = os.path.join(output_folder, 'RF00005'
+    subfolder = os.path.join(output_folder, rfam_acc)
+    os.system('mkdir -p {}'.format(subfolder))
     tblout = os.path.join(subfolder, 'cmsearch.tblout')
-    cmd = 'cmsearch --nohmm --tblout {tblout} {cm} {fasta_input}'.format(
+    cmd = 'cmsearch --nohmm -o {output} --tblout {tblout} {cm} {fasta_input}'.format(
         cm=os.path.join(config.RFAM_DATA, rfam_acc, '{}.cm'.format(rfam_acc)),
+        output=os.path.join(subfolder, 'cmsearch.out.txt'),
         tblout=tblout,
         fasta_input=fasta_input
     )

--- a/utils/rfam.py
+++ b/utils/rfam.py
@@ -553,7 +553,13 @@ def cmsearch_nohmm_mode(fasta_input, output_folder, rfam_acc):
     )
     print(cmd)
     os.system(cmd)
-    f_out = os.path.join(subfolder, 'hits.txt')
-    cmd = "cat %s | grep -v '^#' | awk -v OFS='\t' '{print $1, $4, \"PASS\"}' > %s" % (tblout, f_out)
+    hits = os.path.join(subfolder, 'hits.txt')
+    cmd = "cat %s | grep -v '^#' | awk -v OFS='\t' '{print $1, $4, \"PASS\"}' > %s" % (tblout, hits)
     os.system(cmd)
-    return f_out
+    ids = set()
+    with open(hits, 'r') as f_hits:
+        for line in f_hits:
+            if '\t' in line:
+                hit_id, _, _ = line.strip().split('\t')
+                ids.add(hit_id)
+    return ids

--- a/utils/rfam.py
+++ b/utils/rfam.py
@@ -60,6 +60,8 @@ def get_traveler_fasta(rfam_acc):
 
 
 def get_rfam_cm(rfam_acc):
+    if rfam_acc == 'RF00005':
+        return os.path.join(config.RFAM_DATA, rfam_acc, rfam_acc + '.cm')
     return os.path.join(config.CM_LIBRARY, 'rfam', rfam_acc + '.cm')
 
 


### PR DESCRIPTION
👋 Hi folks! @blakesweeney @carlosribas @biomadeira 

This PR lays the groundwork for some exciting new features in the web UI. It includes 3 new result types: image thumbnails, fasta files, and a metadata report.

There is a now a single folder with all outputs called `results` that contains 4 subfolders:

- `svg` with the same SVG files as before
- `fasta` with sequences and predicted secondary structures in dot-bracket notation 🆕
- `thumbnail` with new SVG files showing a preview of the main SVG image but without labels, colours, and other details 🆕
- `tsv` with a report listing for each sequence which model it matched and where the model came from 🆕

Here is an [example output folder](https://www.dropbox.com/s/1y6odf351qqrnj1/example-output.zip?dl=0). The new code can be tested with `docker pull rnacentral/r2dt:dev`.

@biomadeira - Fabio, would you be able to create 3 new resulttypes in the wwwdev API please?

@carlosribas - Carlos, once the new resulttypes are available in the dev API, could you please bring the R2DT component in sync with the RNAcentral version? You will have the dot-bracket notation and the metadata about hits. You could also use the thumbnail in the sequence search component to show a preview of the full structure.

@blakesweeney - Blake, this update will require some changes in the pipeline but you also get a tsv file that could be useful.

Let me know if you have any questions or feedback.

Closing #33