### PR TITLE
Experiment: run base image builds in parallel

### DIFF
--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -10,6 +10,7 @@ jobs:
   build-stages:
     runs-on: ${{ matrix.runner }}
     strategy:
+      fail-fast: true
       matrix:
         stage: [rscape, tRNAscan-SE, Bio-Easel, traveler, scripts, ribovore-infernal-easel]
         platform: [linux/amd64, linux/arm64]
@@ -22,8 +23,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+#      - name: Set up QEMU
+#        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -33,8 +34,8 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           target: ${{ matrix.stage }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=rnacentral/r2dt-base:cache-${{ matrix.stage }}
+          cache-to: type=registry,ref=rnacentral/r2dt-base:cache-${{ matrix.stage }},mode=max
           file: base_image/Dockerfile
           context: base_image/
 
@@ -73,7 +74,8 @@ jobs:
           push: true
           labels: ${{ steps.docker_meta.outputs.labels }}
           tags: ${{ steps.docker_meta.outputs.tags }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=registry,ref=rnacentral/r2dt-base:cache-final
+          cache-to: type=registry,ref=rnacentral/r2dt-base:cache-final,mode=max
           file: base_image/Dockerfile
           context: base_image/
+          target: final-build

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths:
       - 'base_image/**'
-      - '.github/workflows/base-image.yml'
       - '.github/workflows/parallel-base-image.yml'
 
 jobs:
@@ -23,9 +22,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create a new builder instance
-        run: docker buildx create --use
-
       - name: Docker Meta
         id: docker_meta
         uses: docker/metadata-action@v4
@@ -42,6 +38,12 @@ jobs:
       matrix:
         stage: [rscape, tRNAscan-SE, Bio-Easel, traveler, scripts, ribovore-infernal-easel]
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build ${{ matrix.stage }} stage
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -8,11 +8,16 @@ on:
 
 jobs:
   build-stages:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         stage: [rscape, tRNAscan-SE, Bio-Easel, traveler, scripts, ribovore-infernal-easel]
         platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: 'linux/amd64'
+            runner: 'ubuntu-latest'
+          - platform: 'linux/arm64'
+            runner: 'buildjet-2vcpu-ubuntu-2204-arm'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Build ${{ matrix.stage }} stage
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -66,8 +66,8 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
           push: true
-          labels: ${{ needs.setup.outputs.labels }}
-          tags: ${{ needs.setup.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           file: base_image/Dockerfile

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -7,37 +7,15 @@ on:
       - '.github/workflows/parallel-base-image.yml'
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    outputs:
-      labels: ${{ steps.docker_meta.outputs.labels }}
-      tags: ${{ steps.docker_meta.outputs.tags }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Docker Meta
-        id: docker_meta
-        uses: docker/metadata-action@v4
-        with:
-          images: rnacentral/r2dt-base
-          flavor: latest=false
-          tags: |
-            type=ref,event=pr
-
   build-stages:
-    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
         stage: [rscape, tRNAscan-SE, Bio-Easel, traveler, scripts, ribovore-infernal-easel]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
 
@@ -58,6 +36,15 @@ jobs:
     needs: build-stages
     runs-on: ubuntu-latest
     steps:
+      - name: Docker Meta
+        id: docker_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: rnacentral/r2dt-base
+          flavor: latest=false
+          tags: |
+            type=ref,event=pr
+
       - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         stage: [rscape, tRNAscan-SE, Bio-Easel, traveler, scripts, ribovore-infernal-easel]
+        platform: [linux/amd64, linux/arm64]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -25,7 +26,7 @@ jobs:
       - name: Build ${{ matrix.stage }} stage
         uses: docker/build-push-action@v5
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           target: ${{ matrix.stage }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -36,6 +37,15 @@ jobs:
     needs: build-stages
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker Meta
         id: docker_meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Create a new builder instance
+        run: docker buildx create --use
+
       - name: Docker Meta
         id: docker_meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -1,0 +1,72 @@
+name: Build and Push Base Docker image
+
+on:
+  pull_request:
+    paths:
+      - 'base_image/**'
+      - '.github/workflows/base-image.yml'
+      - '.github/workflows/parallel-base-image.yml'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      labels: ${{ steps.docker_meta.outputs.labels }}
+      tags: ${{ steps.docker_meta.outputs.tags }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker Meta
+        id: docker_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: rnacentral/r2dt-base
+          flavor: latest=false
+          tags: |
+            type=ref,event=pr
+
+  build-stages:
+    needs: setup
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stage: [rscape, tRNAscan-SE, Bio-Easel, traveler, scripts, ribovore-infernal-easel]
+    steps:
+      - name: Build ${{ matrix.stage }} stage
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          target: ${{ matrix.stage }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: base_image/Dockerfile
+          context: base_image/
+
+  final-build:
+    needs: build-stages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push final Docker image
+        uses: docker/build-push-action@v5
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          labels: ${{ needs.setup.outputs.labels }}
+          tags: ${{ needs.setup.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          file: base_image/Dockerfile
+          context: base_image/

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -17,8 +17,10 @@ jobs:
         include:
           - platform: 'linux/amd64'
             runner: 'ubuntu-latest'
+            shorthand: 'amd64'
           - platform: 'linux/arm64'
             runner: 'buildjet-2vcpu-ubuntu-2204-arm'
+            shorthand: 'arm64'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -37,8 +39,8 @@ jobs:
         with:
           platforms: ${{ matrix.platform }}
           target: ${{ matrix.stage }}
-          cache-from: type=registry,ref=rnacentral/r2dt-base:cache-${{ matrix.stage }}
-          cache-to: type=registry,ref=rnacentral/r2dt-base:cache-${{ matrix.stage }},mode=max
+          cache-from: type=registry,ref=rnacentral/r2dt-base:cache-${{ matrix.stage }}-${{ matrix.shorthand }}
+          cache-to: type=registry,ref=rnacentral/r2dt-base:cache-${{ matrix.stage }}-${{ matrix.shorthand }},mode=max
           file: base_image/Dockerfile
           context: base_image/
 
@@ -78,12 +80,20 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           cache-from: |
-            type=registry,ref=rnacentral/r2dt-base:cache-rscape
-            type=registry,ref=rnacentral/r2dt-base:cache-tRNAscan-SE
-            type=registry,ref=rnacentral/r2dt-base:cache-Bio-Easel
-            type=registry,ref=rnacentral/r2dt-base:cache-traveler
-            type=registry,ref=rnacentral/r2dt-base:cache-scripts
-            type=registry,ref=rnacentral/r2dt-base:cache-ribovore-infernal-easel
+            type=registry,ref=rnacentral/r2dt-base:cache-rscape-amd64
+            type=registry,ref=rnacentral/r2dt-base:cache-tRNAscan-SE-amd64
+            type=registry,ref=rnacentral/r2dt-base:cache-Bio-Easel-amd64
+            type=registry,ref=rnacentral/r2dt-base:cache-traveler-amd64
+            type=registry,ref=rnacentral/r2dt-base:cache-scripts-amd64
+            type=registry,ref=rnacentral/r2dt-base:cache-ribovore-infernal-easel-amd64
+
+            type=registry,ref=rnacentral/r2dt-base:cache-rscape-arm64
+            type=registry,ref=rnacentral/r2dt-base:cache-tRNAscan-SE-arm64
+            type=registry,ref=rnacentral/r2dt-base:cache-Bio-Easel-arm64
+            type=registry,ref=rnacentral/r2dt-base:cache-traveler-arm64
+            type=registry,ref=rnacentral/r2dt-base:cache-scripts-arm64
+            type=registry,ref=rnacentral/r2dt-base:cache-ribovore-infernal-easel-arm64
+
             type=registry,ref=rnacentral/r2dt-base:cache-final
           cache-to: type=registry,ref=rnacentral/r2dt-base:cache-final,mode=max
           file: base_image/Dockerfile

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -23,9 +23,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-#      - name: Set up QEMU
-#        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -80,7 +77,14 @@ jobs:
           push: true
           labels: ${{ steps.docker_meta.outputs.labels }}
           tags: ${{ steps.docker_meta.outputs.tags }}
-          cache-from: type=registry,ref=rnacentral/r2dt-base:cache-final
+          cache-from: |
+            type=registry,ref=rnacentral/r2dt-base:cache-rscape
+            type=registry,ref=rnacentral/r2dt-base:cache-tRNAscan-SE
+            type=registry,ref=rnacentral/r2dt-base:cache-Bio-Easel
+            type=registry,ref=rnacentral/r2dt-base:cache-traveler
+            type=registry,ref=rnacentral/r2dt-base:cache-scripts
+            type=registry,ref=rnacentral/r2dt-base:cache-ribovore-infernal-easel
+            type=registry,ref=rnacentral/r2dt-base:cache-final
           cache-to: type=registry,ref=rnacentral/r2dt-base:cache-final,mode=max
           file: base_image/Dockerfile
           context: base_image/

--- a/.github/workflows/parallel-base-image.yml
+++ b/.github/workflows/parallel-base-image.yml
@@ -1,4 +1,4 @@
-name: Build and Push Base Docker image
+name: Build and Push Base Docker image (parallel)
 
 on:
   pull_request:


### PR DESCRIPTION
There are 2 changes to the base image build process in this PR:

1. Parallelise different stages and platforms for the base image build. This per se reduces full build time from ~90 minutes to ~45, while arm build on an x86 machine being the slowest part: 2 sub-builds for arm on x86 via QEMU take 40 minutes each, whereas everything else is built in ~10 minutes. Nevertheless, this change can be accepted in isolation for moving from 90 to 45 minutes per full build.
2. An additional change is to use BuildJet's (https://buildjet.com) native ARM worker for arm builds. This significantly speeds the ARM builds up (everything is under 10 minutes now), but costs money: 1 minute of ARM builder is $0.004; full re-build (without cache) is ~15 minutes of workers total or $0.06; 10 base image builds per month is $0.6. However, a malicious actor might in theory create hundreds of PRs, triggering hundreds of builds and costing money. Doing so doesn't make much sense for the attacker (unless R2DT has enemies qualified in Dockerfile trickery, or unless BuildJet itself doesn't decide to earn extra $10 on this initiative), but is a possibility.

We can adopt just item 1, or both 1+2, or alternatively we could deploy a GitHub Actions runner on the free Oracle Cloud ARM64 machine, but I'm not sure how much of a speedup that would be. That would be an alternative to the item 2.