### PR TITLE
Add procps to base image

### DIFF
--- a/base_image/Dockerfile
+++ b/base_image/Dockerfile
@@ -102,6 +102,7 @@ RUN \
     python3-pip  \
     python3-venv  \
     python3-cairo  \
+    procps \
     perl &&  \
     rm -rf /var/lib/{apt,lpkg,cache,log}
 RUN \


### PR DESCRIPTION
For nextflow compatibility

Nextflow runs a whole process in container, including the collection of trace data for which it uses ps. 

The slim build doesn't have ps installed by default, so this just adds it back in. I don't think it will introduce too many additional dependencies.