### PR TITLE
Add required tools to the codespace image

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,5 +4,7 @@ RUN wget -qO - 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg 
     echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list && \
     sudo apt-get -qq update && \
     sudo apt-get install --no-install-recommends -qq -y \
+    imagemagick \
+    libmagickwand-dev \
     chafa \
     just

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/universal:2-linux
+
+RUN wget -qO - 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null && \
+    echo "deb [arch=all,$(dpkg --print-architecture) signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list && \
+    sudo apt-get -qq update && \
+    sudo apt-get install --no-install-recommends -qq -y \
+    chafa \
+    just

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,15 @@
   "name": "R2DT",
   "build": {
     "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-vscode-remote.remote-containers",
+        "ms-azuretools.vscode-docker"
+      ]
+    }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,6 @@
+{
+  "name": "R2DT",
+  "build": {
+    "dockerfile": ".devcontainer/Dockerfile"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "R2DT",
   "build": {
-    "dockerfile": ".devcontainer/Dockerfile"
+    "dockerfile": "Dockerfile"
   }
 }

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,8 @@ R2DT can be used in a number of ways:
 * [API](https://www.ebi.ac.uk/Tools/common/tools/help/index.html?tool=r2dt) powered by EMBL-EBI Web Services
 * As a command line tool with [Docker](https://www.docker.com), [Singularity](https://sylabs.io/docs/#singularity), or in a bare metal installation
 
+You can also [![open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/RNAcentral/R2DT)
+
 ## Citation
 
 If you use R2DT in your work, please consider citing the following paper:

--- a/base_image/Dockerfile
+++ b/base_image/Dockerfile
@@ -102,6 +102,7 @@ RUN \
     python3-pip  \
     python3-venv  \
     python3-cairo  \
+    chafa \
     perl &&  \
     rm -rf /var/lib/{apt,lpkg,cache,log}
 RUN \

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,5 +1,0 @@
-{
-  "name": "R2DT",
-  "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
-  "postCreateCommand": "sudo apt-get -qq update && sudo apt-get install --no-install-recommends -qq -y chafa && curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --crate just --force --to /usr/local/bin"
-}

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "name": "R2DT",
+  "postCreateCommand": "sudo apt-get -qq update && sudo apt-get install --no-install-recommends -qq -y chafa && curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --crate just --force --to /usr/local/bin"
+}

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,4 +1,5 @@
 {
   "name": "R2DT",
+  "image": "mcr.microsoft.com/devcontainers/universal:2-linux",
   "postCreateCommand": "sudo apt-get -qq update && sudo apt-get install --no-install-recommends -qq -y chafa && curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --crate just --force --to /usr/local/bin"
 }


### PR DESCRIPTION
This adds `chafa` and `just` to the dev image.

One can play with it via
<img width="588" alt="Untitled" src="https://github.com/RNAcentral/R2DT/assets/17383/d871231c-1dfa-49d4-b0e7-3683e78af84a">

P.S. Don't forget to shutdown your codespace when you don't need it
P.P.S. Note this also adds `chafa` to the base image for future usage in R2DT