### PR TITLE
Update docs conf.py to configure canonical URL

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@ author = "R2DT Team"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
+import os
+
 import sphinx_rtd_theme
 
 extensions = [
@@ -39,3 +41,14 @@ html_theme_options = {
 
 # -- Options for MyST parser -------------------------------------------------
 myst_heading_anchors = 3
+
+# -- Read the Docs Canonical URL -----------------------------------------------
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    if "html_context" not in globals():
+        html_context = {}
+    html_context["READTHEDOCS"] = True


### PR DESCRIPTION
The change was triggered by the [update in RTD](https://about.readthedocs.com/blog/2024/07/addons-by-default/).