### PR TITLE
Bump Pillow to >=11.0 for Python 3.13 compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx-autobuild==2021.3.14
 viennarna==2.6.4
 rich==13.5.2
 cairosvg==2.7.1
-Pillow==10.0.1
+Pillow>=11.0
 scikit-image>=0.24.0
 Jinja2==3.1.6
 numpy>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ sphinx-autobuild==2021.3.14
 viennarna==2.6.4
 rich==13.5.2
 cairosvg==2.7.1
-Pillow>=11.0
+Pillow>=11.0,<13
 scikit-image>=0.24.0
 Jinja2==3.1.6
 numpy>=2.0.0


### PR DESCRIPTION
## Summary

`requirements.txt` pins `Pillow==10.0.1`, which does not build on Python 3.13. Installing R2DT into a Python 3.13 venv fails at the Pillow build step with:

KeyError: 'version'



while pip is reading Pillow 10.0.1's `pyproject.toml`. Pillow 11.0 was the first release line to officially support Python 3.13, and 12.x continues that support.

This PR relaxes the pin to `Pillow>=11.0`, which:

- Unblocks installs on Python 3.13.
- Leaves existing Python 3.10–3.12 installs working (those interpreters can still pull newer Pillow without issue).
- Avoids over-constraining to an exact version that would require another bump on the next compatibility break.

## Reproduction

```bash
python3.13 -m venv venv
source venv/bin/activate
pip install --upgrade pip
pip install -r requirements.txt
# → fails on Pillow==10.0.1 with KeyError: '__version__'
```
With this change, the same steps succeed (Pillow 12.2.0 is selected) and python r2dt.py --help runs cleanly.